### PR TITLE
Change title of website "AddressBook-Level3" to "Coupon Stash"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,8 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level3',
-        'site-githuburl': 'https://github.com/se-edu/addressbook-level3',
-        'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
+        'site-name': 'Coupon Stash',
+        'site-githuburl': 'https://github.com/AY1920S2-CS2103T-F09-1/main'
     ]
 
     options['template_dirs'].each {


### PR DESCRIPTION
In this commit, the title set in build.gradle is changed to reflect the new project. Also, the navigation bar for SE-EDU projects was removed