### PR TITLE
Remove Learning Outcomes from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,6 @@ Save your life with Coupon Stash.
 
 * <<UserGuide#, User Guide>>
 * <<DeveloperGuide#, Developer Guide>>
-* <<LearningOutcomes#, Learning Outcomes>>
 * <<AboutUs#, About Us>>
 * <<ContactUs#, Contact Us>>
 


### PR DESCRIPTION
This document is not referenced anywhere else, so might as well just remove it from the README

Todo: remove the file from the docs as well