### PR TITLE
Fix link in ContactUs to point to correct issue tracker

### DIFF
--- a/docs/ContactUs.adoc
+++ b/docs/ContactUs.adoc
@@ -2,7 +2,7 @@
 :site-section: ContactUs
 :stylesDir: stylesheets
 
-* *Bug reports, Suggestions* : Post in our https://github.com/se-edu/addressbook-level3/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
+* *Bug reports, Suggestions* : Post in our https://github.com/AY1920S2-CS2103T-F09-1/main/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
 * *Contributing* : We welcome pull requests. Follow the process described https://github.com/oss-generic/process[here]
 * *Email us* : You can also reach us at +
 ** chestersimdingyi@u.nus.edu


### PR DESCRIPTION
The link in ContactUs still points to Address Book's issue tracker. Let's fix this