### PR TITLE
Fix erroneous coupon reference in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,13 @@
 MIT License
 
-Copyright (c) 2016 Software Engineering Education - FOSS Resources
+Modified work - Copyright (c) 2020 Coupon Stash Developers
+Original work - Copyright (c) 2016 Software Engineering Education - FOSS Resources
 
-Permission is hereby granted, free of charge, to any coupon obtaining a copy
+Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit coupons to whom the Software is
+copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all


### PR DESCRIPTION
* Also, add proper attribution to CS Dev

* Resolves #89