### PR TITLE
Implement rudimentary sort and fix arrow key history bug

### DIFF
--- a/src/main/java/csdev/couponstash/logic/commands/SortCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/SortCommand.java
@@ -44,7 +44,7 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model, String commandText) throws CommandException {
         requireNonNull(model);
 
-        model.sortCoupons(prefixToSortBy);
+        model.sortCoupons(prefixToSortBy, commandText);
 
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, prefixToSortBy.toString())

--- a/src/main/java/csdev/couponstash/model/CouponStash.java
+++ b/src/main/java/csdev/couponstash/model/CouponStash.java
@@ -2,6 +2,8 @@ package csdev.couponstash.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import csdev.couponstash.model.coupon.Coupon;
@@ -46,6 +48,14 @@ public class CouponStash implements ReadOnlyCouponStash {
      */
     public void setCoupons(List<Coupon> coupons) {
         this.coupons.setCoupons(coupons);
+    }
+
+    public void sortCoupons(Comparator<Coupon> comp) {
+        List<Coupon> sorted =
+                new ArrayList<>(copy().getCouponList());
+        sorted.sort(comp);
+
+        setCoupons(sorted);
     }
 
     /**

--- a/src/main/java/csdev/couponstash/model/CouponStash.java
+++ b/src/main/java/csdev/couponstash/model/CouponStash.java
@@ -2,8 +2,6 @@ package csdev.couponstash.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import csdev.couponstash.model.coupon.Coupon;
@@ -48,14 +46,6 @@ public class CouponStash implements ReadOnlyCouponStash {
      */
     public void setCoupons(List<Coupon> coupons) {
         this.coupons.setCoupons(coupons);
-    }
-
-    public void sortCoupons(Comparator<Coupon> comp) {
-        List<Coupon> sorted =
-                new ArrayList<>(copy().getCouponList());
-        sorted.sort(comp);
-
-        setCoupons(sorted);
     }
 
     /**

--- a/src/main/java/csdev/couponstash/model/Model.java
+++ b/src/main/java/csdev/couponstash/model/Model.java
@@ -133,7 +133,6 @@ public interface Model {
     /**
      * Sorts coupons in the coupon stash according to the field specified
      * by the prefix.
-     * @param prefixToSortBy
      */
-    void sortCoupons(Prefix prefixToSortBy);
+    void sortCoupons(Prefix prefixToSortBy, String commandText);
 }

--- a/src/main/java/csdev/couponstash/model/history/CommandTextHistory.java
+++ b/src/main/java/csdev/couponstash/model/history/CommandTextHistory.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 /**
  * This class stores all the commandText that was executed in STASH. Does not matter
- * if the commands had errors, they are still stored and can be retrived by pressing up or down on
+ * if the commands had errors, they are still stored and can be retrieved by pressing up or down on
  * the keyboard.
  */
 public class CommandTextHistory {
@@ -15,7 +15,8 @@ public class CommandTextHistory {
     public CommandTextHistory() {
         commandTextHistory = new ArrayList<>();
         commandTextHistory.add("");
-        currIndex = 0;
+        commandTextHistory.add("");
+        currIndex = 1;
     }
 
     /**
@@ -24,7 +25,8 @@ public class CommandTextHistory {
      */
     public void add(String commandText) {
         commandTextHistory.add(commandText);
-        currIndex++;
+        commandTextHistory.add("");
+        currIndex = commandTextHistory.size() - 1;
     }
 
     /**
@@ -35,7 +37,12 @@ public class CommandTextHistory {
         if (currIndex == commandTextHistory.size() - 1) {
             return "";
         } else {
-            return commandTextHistory.get(++currIndex);
+            currIndex += 2;
+            if (currIndex + 1 > commandTextHistory.size() - 1) {
+                return "";
+            } else {
+                return commandTextHistory.get(currIndex + 1);
+            }
         }
     }
 
@@ -44,10 +51,13 @@ public class CommandTextHistory {
      * @return last input commandText.
      */
     public String getUp() {
-        if (currIndex <= 1) {
-            return commandTextHistory.get(currIndex);
+        if (currIndex == 1) {
+            return commandTextHistory.size() > 2
+                    ? commandTextHistory.get(currIndex + 1)
+                    : "";
         } else {
-            return commandTextHistory.get(currIndex--);
+            currIndex -= 2;
+            return commandTextHistory.get(currIndex + 1);
         }
     }
 }

--- a/src/test/java/csdev/couponstash/logic/commands/AddCommandTest.java
+++ b/src/test/java/csdev/couponstash/logic/commands/AddCommandTest.java
@@ -187,7 +187,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void sortCoupons(Prefix prefixToSortBy) {
+        public void sortCoupons(Prefix prefixToSortBy, String commandText) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Sort now works only in ascending order. Plus, it only works on 2 fields: name and expiry date. Maybe come up with a default sorting (probably impossible) and allow user to choose ascending or descending.

Arrow key history bug was stupid and the solution is stupider....

Tests not added yet, will do so soon hopefully...