### PR TITLE
Fix used command error message

### DIFF
--- a/src/main/java/csdev/couponstash/logic/commands/UsedCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/UsedCommand.java
@@ -1,6 +1,5 @@
 package csdev.couponstash.logic.commands;
 
-import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_SAVINGS;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;

--- a/src/main/java/csdev/couponstash/logic/commands/UsedCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/UsedCommand.java
@@ -27,9 +27,9 @@ public class UsedCommand extends Command {
             + "identified by the index number used in the displayed coupon list. "
             + "This increases the value of its usage by one.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_SAVINGS + "Original amount of purchase (optional)\n"
-            + "Example: " + COMMAND_WORD + " 1"
-            + "Example with Savings: " + COMMAND_WORD + "1 " + PREFIX_SAVINGS + "$100";
+            + "[%s" + "(Original amount of purchase)]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example with Savings: " + COMMAND_WORD + " 1 " + "%s100";
 
     public static final String MESSAGE_USED_COUPON_SUCCESS = "Used Coupon: %1$s";
     public static final String MESSAGE_USAGE_LIMIT_REACHED = "Coupon usage limit has been reached!\n"

--- a/src/main/java/csdev/couponstash/logic/parser/UsedCommandParser.java
+++ b/src/main/java/csdev/couponstash/logic/parser/UsedCommandParser.java
@@ -24,6 +24,7 @@ public class UsedCommandParser implements Parser<UsedCommand> {
      * @param moneySymbol String representing the money symbol.
      */
     public UsedCommandParser(String moneySymbol) {
+        System.out.println(moneySymbol);
         this.moneySymbol = moneySymbol;
     }
 
@@ -58,8 +59,8 @@ public class UsedCommandParser implements Parser<UsedCommand> {
                 return new UsedCommand(index, originalAmount);
             }
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UsedCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    String.format(UsedCommand.MESSAGE_USAGE, moneySymbol, moneySymbol)), pe);
         }
     }
 }

--- a/src/test/java/csdev/couponstash/logic/parser/UsedCommandParserTest.java
+++ b/src/test/java/csdev/couponstash/logic/parser/UsedCommandParserTest.java
@@ -14,7 +14,8 @@ public class UsedCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         CommandParserTestUtil.assertParseFailure(parser,
-                "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UsedCommand.MESSAGE_USAGE));
+                "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        String.format(UsedCommand.MESSAGE_USAGE, VALID_MONEY_SYMBOL, VALID_MONEY_SYMBOL)));
     }
 
     @Test void parse_validArgs_returnsUsedCommand() {


### PR DESCRIPTION
Previously, it was showing something like this:
```
used 1 s/$100
```
Now, it does not mention the "s/" prefix, and uses the correct money symbol from user preferences
so the user knows how to change it