### PR TITLE
Fix the spelling of currently

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -460,7 +460,7 @@ Exports the 1st coupon in the results of the find command to an `add` command an
 
 === Set user preferences: `setpref`
 Sets the user preferences in Coupon Stash. Available user
-preferences currenly consist of:
+preferences currently consist of:
 
 * The symbol used to represent monetary amount
 


### PR DESCRIPTION
Currently, the currently word was spelled as currenly instead of currently. Currently, this Pull Request is to fix the spelling of currently such that it will no longer currently be currenly but be currently currently instead currently