### PR TITLE
Show a small message for Coupons without numerical savings

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -177,16 +177,24 @@ are multiple same parameters for parameters that require only one parameter)
 
 === Adding a coupon: `add`
 
-Adds a coupon. Some fields like `name`, `expiry date` and `savings` are required. Optional fields like `promo code` and `tags` may be provided as well.
+Adds a coupon. Some fields like `name`, `expiry date` and `savings` are required.
+Optional fields like `promo code` and `tags` may be provided as well.
 
-Format: `add n/NAME e/EXPIRY_DATE s/SAVINGS [sd/START_DATE] [p/PROMO_CODE]
-[c/CONDITIONS] [u/USAGE] [l/USAGE_LIMIT] [s/FREE_ITEMS]... [t/TAG]...`
+Format: `add n/NAME e/EXPIRY_DATE s/SAVINGS_OR_FREE_ITEM [sd/START_DATE] [p/PROMO_CODE]
+[c/CONDITIONS] [u/USAGE] [l/USAGE_LIMIT] [s/EXTRA_FREE_ITEMS]... [t/TAG]...`
 
 [TIP]
 A coupon can have any number of tags (including 0)
 
-[NOTE]
-`SAVINGS` and `FREE_ITEMS` share the same prefix
+****
+* Coupons must have at least one "savings" value, whether it is
+a flat monetary amount (e.g. $1.00), a percentage (e.g. 10%) or
+an item (e.g. Free Water Bottle).
+* Savings can be represented by multiple free items, but not multiple
+monetary amounts or percentage amounts.
+* Coupons cannot have both a monetary amount and a percentage amount.
+* To add more free items, use the same prefix as before!
+****
 
 Examples:
 

--- a/src/main/java/csdev/couponstash/ui/SavingsBox.java
+++ b/src/main/java/csdev/couponstash/ui/SavingsBox.java
@@ -18,6 +18,10 @@ public class SavingsBox extends UiPart<Region> {
     private static final String HIDDEN = "visibility: hidden;";
     // allow CSS styles for each label in the FlowPane
     private static final String SAVEABLE_CLASS = "sv-label";
+    // make it more obvious that savings can exist without
+    // numerical but with saveable free items
+    private static final String NO_NUMERICAL_AMOUNT_STYLE = "-fx-font-size: 12;"
+            + "-fx-font-weight: normal; -fx-font-style: italic; -fx-text-fill: #6c96be;";
     // controls font size of number amount
     private static final int BASE_FONT_SIZE = 125;
     // if no saveables, translate numerical amount
@@ -56,7 +60,8 @@ public class SavingsBox extends UiPart<Region> {
         // handle numerical value
         String savingsNumber = getSavingsString(s, moneySymbol);
         if (savingsNumber.isBlank()) {
-            this.numericalAmount.setStyle(SavingsBox.HIDDEN);
+            this.numericalAmount.setText("(no amount)");
+            this.numericalAmount.setStyle(SavingsBox.NO_NUMERICAL_AMOUNT_STYLE);
         } else {
             this.numericalAmount.setText(savingsNumber);
             // resize numerical amount dynamically


### PR DESCRIPTION
Resolves #256, by making it more obvious in the UI that savings can be added only with free items

Also, User Guide is updated to clarify this

Preview:
![image](https://user-images.githubusercontent.com/49450743/78505933-31fc0600-77a9-11ea-8a70-1ef0c724bf58.png)
