### PR TITLE
Disallow numbers that are not monetary or percentage values

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -163,9 +163,7 @@ times)
 ** e.g. `[t/TAG]...`​
 ** can be used as `t/pizza`, `t/friend t/value` or not used at all etc.
 * Parameters can be in any order
-** e.g. specifying `n/NAME s/SAVINGS` is the same as `s/SAVINGS n/NAME` +
-(Note: Coupon Stash will only take the last specified parameter into account if there
-are multiple same parameters for parameters that require only one parameter)
+** e.g. specifying `n/NAME s/SAVINGS` is the same as `s/SAVINGS n/NAME`
 * Dates are all in the D-M-YYYY format (Coupon Stash date format)
 ** D and M can be one or two digits, but YYYY has to be four digits
 ** e.g. `1-1-2020` and `01-01-2020` are valid dates

--- a/src/main/java/csdev/couponstash/model/coupon/savings/Savings.java
+++ b/src/main/java/csdev/couponstash/model/coupon/savings/Savings.java
@@ -30,11 +30,15 @@ import csdev.couponstash.model.coupon.exceptions.InvalidSavingsException;
  * see 50% off by itself, or $1 off by itself.
  */
 public class Savings implements Comparable<Savings> {
-    public static final String MESSAGE_CONSTRAINTS = "Savings should not be blank, "
-            + "and savings cannot have both a monetary amount and a percentage amount.";
+    public static final String MESSAGE_CONSTRAINTS = "Savings should not be blank!";
     public static final String EMPTY_LIST_ERROR =
             "ERROR: Parser identified that this Savings should have"
             + "Saveables, but no Saveables received in class Savings";
+    public static final String NUMBER_DETECTED_BUT_NOT_IN_FORMAT =
+            "For savings, did you mean to specify a percentage amount (e.g. s/10%%)"
+                    + " or a monetary amount (e.g. s/%1$s1.00)?";
+    public static final String MULTIPLE_NUMBER_AMOUNTS =
+            "Please only specify one numerical amount for savings.";
 
     // coupons could have a certain monetary value
     private final Optional<MonetaryAmount> monetaryAmount;

--- a/src/test/java/csdev/couponstash/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/csdev/couponstash/logic/parser/AddCommandParserTest.java
@@ -70,11 +70,6 @@ public class AddCommandParserTest {
                 + EXPIRY_DATE_DESC_BOB + START_DATE_DESC_BOB + LIMIT_DESC_BOB + TAG_DESC_FRIEND,
                 new AddCommand(expectedCoupon));
 
-        // multiple savings monetary amount - last one accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + PROMO_CODE_DESC_BOB + SAVINGS_DESC_BOB_TWO_MONETARY_AMOUNT
-                + EXPIRY_DATE_DESC_BOB + START_DATE_DESC_BOB + LIMIT_DESC_BOB + TAG_DESC_FRIEND,
-                new AddCommand(expectedCoupon));
-
         // multiple limits - last limit accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PROMO_CODE_DESC_BOB + SAVINGS_DESC_BOB
                 + EXPIRY_DATE_DESC_BOB + START_DATE_DESC_BOB + LIMIT_DESC_AMY + LIMIT_DESC_BOB
@@ -153,6 +148,11 @@ public class AddCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + PROMO_CODE_DESC_BOB + INVALID_SAVINGS_DESC
                 + EXPIRY_DATE_DESC_BOB + LIMIT_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND,
                 Savings.MESSAGE_CONSTRAINTS);
+
+        // multiple savings monetary amount fails
+        assertParseFailure(parser, NAME_DESC_BOB + PROMO_CODE_DESC_BOB + SAVINGS_DESC_BOB_TWO_MONETARY_AMOUNT
+                        + EXPIRY_DATE_DESC_BOB + START_DATE_DESC_BOB + LIMIT_DESC_BOB + TAG_DESC_FRIEND,
+                Savings.MULTIPLE_NUMBER_AMOUNTS);
 
         // non-addable usage
         assertParseFailure(parser, NAME_DESC_BOB + PROMO_CODE_DESC_BOB + SAVINGS_DESC_BOB + EXPIRY_DATE_DESC_BOB


### PR DESCRIPTION
Seems like this was a big source of confusion for the beta testers!

Another change: error message for blank Savings field and presence of both monetary and percentage amounts have been split up (resolves #269)

Error for both monetary and percentage amount:
![image](https://user-images.githubusercontent.com/49450743/78506711-2d861c00-77ae-11ea-820e-a3ca8e9ec1a0.png)

Error for blank savings:
![image](https://user-images.githubusercontent.com/49450743/78506817-ec423c00-77ae-11ea-8404-b3fbc175c381.png)

Error for any numerical amount that is not monetary or percentage: (resolves #273, #255, also resolves #262 by extension)
![image](https://user-images.githubusercontent.com/49450743/78506832-00863900-77af-11ea-8557-e4879e93a9ea.png)

Also, in this change the add and edit commands will no longer accept multiple monetary amounts
and multiple percentage amounts. User Guide has been updated to reflect this (resolves #255)