### PR TITLE
Fixed undo redo, help command now works offline, and allow sorting by remind date

### DIFF
--- a/src/main/java/csdev/couponstash/logic/commands/ExitCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/ExitCommand.java
@@ -11,7 +11,7 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting CouponStash as requested ...";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Exits the program.\n"
+            + ": Exits the program.\n\n"
             + "Example: " + COMMAND_WORD;
 
     @Override

--- a/src/main/java/csdev/couponstash/logic/commands/HelpCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/HelpCommand.java
@@ -42,7 +42,7 @@ public class HelpCommand extends Command {
     }
 
     /**
-     * Return URI of help.html. If help.html is not extracted from jar file yet,
+     * Get URI of help.html. If help.html is not extracted from jar file yet,
      * extract it.
      * @return URI of help.html
      * @throws CommandException

--- a/src/main/java/csdev/couponstash/logic/commands/RedoCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/RedoCommand.java
@@ -15,7 +15,7 @@ public class RedoCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Undone command redone: %s";
     public static final String MESSAGE_NO_STATE_TO_REDO_TO = "Nothing to redo";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Redo the previously undone command.\n"
+            + ": Redo the previously undone command.\n\n"
             + "Example: " + COMMAND_WORD;
 
     @Override

--- a/src/main/java/csdev/couponstash/logic/commands/ShareCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/ShareCommand.java
@@ -93,4 +93,11 @@ public class ShareCommand extends IndexedCommand {
 
         return new CommandResult(String.format(MESSAGE_SHARE_COUPON_SUCCESS, file.getAbsolutePath()));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof ShareCommand
+                && targetIndex.equals(((ShareCommand) other).targetIndex));
+    }
 }

--- a/src/main/java/csdev/couponstash/logic/commands/SortCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/SortCommand.java
@@ -2,6 +2,7 @@ package csdev.couponstash.logic.commands;
 
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_NAME;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_REMIND;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +42,12 @@ public class SortCommand extends Command {
             .compareTo(
                     y.getExpiryDate().getDate()
             );
+    public static final Comparator<Coupon> REMINDER_COMPARATOR = (x, y) -> x
+            .getRemindDate()
+            .getDate()
+            .compareTo(
+                    y.getRemindDate().getDate()
+            );
 
     private Prefix prefixToSortBy;
 
@@ -63,9 +70,9 @@ public class SortCommand extends Command {
             model.sortCoupons(NAME_COMPARATOR);
         } else if (prefixToSortBy.equals(PREFIX_EXPIRY_DATE)) {
             model.sortCoupons(EXPIRY_COMPARATOR);
+        } else if (prefixToSortBy.equals(PREFIX_REMIND)) {
+            model.sortCoupons(REMINDER_COMPARATOR);
         }
-
-
 
         // Put non-archived at the top.
         model.sortCoupons(Model.COMPARATOR_NON_ARCHVIED_FIRST);

--- a/src/main/java/csdev/couponstash/logic/commands/UndoCommand.java
+++ b/src/main/java/csdev/couponstash/logic/commands/UndoCommand.java
@@ -16,7 +16,7 @@ public class UndoCommand extends Command {
     public static final String MESSAGE_NO_STATE_TO_UNDO_TO = "No commands to undo";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Undo previous operation. "
-            + "Only operations that change the coupons in the coupon stash can be undone.\n"
+            + "Only operations that change the coupons in the coupon stash can be undone.\n\n"
             + "Example: " + COMMAND_WORD;
 
     @Override

--- a/src/main/java/csdev/couponstash/logic/parser/SortCommandParser.java
+++ b/src/main/java/csdev/couponstash/logic/parser/SortCommandParser.java
@@ -3,6 +3,7 @@ package csdev.couponstash.logic.parser;
 import static csdev.couponstash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_NAME;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_REMIND;
 import static java.util.Objects.requireNonNull;
 
 import csdev.couponstash.logic.commands.SortCommand;
@@ -15,30 +16,60 @@ import csdev.couponstash.logic.parser.exceptions.ParseException;
  * @throws ParseException if the user input does not conform the expected format
  */
 public class SortCommandParser implements Parser<SortCommand> {
+
+    // Prefixes that we can sort by.
+    private static final Prefix[] supportedPrefixes = new Prefix[] {
+        PREFIX_EXPIRY_DATE,
+        PREFIX_NAME,
+        PREFIX_REMIND
+    };
+
     @Override
     public SortCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultiMap = ArgumentTokenizer
-                .tokenize(args, PREFIX_NAME, PREFIX_EXPIRY_DATE);
+                .tokenize(args, supportedPrefixes);
 
-        if (
-                argMultiMap.getValue(PREFIX_NAME).isPresent()
-                        && !argMultiMap.getValue(PREFIX_EXPIRY_DATE).isPresent()
-        ) {
-            // Only has PREFIX_NAME
-            return new SortCommand(PREFIX_NAME);
-        } else if (
-                !argMultiMap.getValue(PREFIX_NAME).isPresent()
-                        && argMultiMap.getValue(PREFIX_EXPIRY_DATE).isPresent()
-        ) {
-            // Only has PREFIX_EXPIRY_DATE
-            return new SortCommand(PREFIX_EXPIRY_DATE);
-        } else {
-            // Has both prefixes or has none
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            SortCommand.MESSAGE_USAGE)
-            );
+        return new SortCommand(getPrefix(argMultiMap));
+    }
+
+    /**
+     * Get the prefix in the argumentMultiMap.
+     * @param argumentMultimap
+     * @return Prefix in the argumentMultiMap
+     * @throws ParseException Thrown if argumentMultiMap contains 0 or more than one valid prefix
+     */
+    private static Prefix getPrefix(ArgumentMultimap argumentMultimap) throws ParseException {
+        if (hasOnlyOneValidPrefix(argumentMultimap)) {
+            for (Prefix prefix : supportedPrefixes) {
+                if (argumentMultimap.getValue(prefix).isPresent()) {
+                    return prefix;
+                }
+            }
         }
+
+        // Has more than one prefixes or has none
+        throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        SortCommand.MESSAGE_USAGE)
+        );
+    }
+
+    /**
+     * Check if ArgumentMultimap only has one valid prefix. Valid prefixes
+     * are those contained in the array supportedPrefixes
+     * @param argumentMultimap
+     * @return True if ArgumentMultimap only has one valid prefix, false otherwise
+     */
+    private static boolean hasOnlyOneValidPrefix(ArgumentMultimap argumentMultimap) {
+        int count = 0;
+
+        for (Prefix prefix : supportedPrefixes) {
+            if (argumentMultimap.getValue(prefix).isPresent()) {
+                count++;
+            }
+        }
+
+        return count == 1;
     }
 }

--- a/src/main/java/csdev/couponstash/model/history/HistoryManager.java
+++ b/src/main/java/csdev/couponstash/model/history/HistoryManager.java
@@ -33,19 +33,19 @@ public class HistoryManager {
      * @param newState State to add to {@code couponStashList}
      */
     public void commitState(CouponStash newState, String command) {
-        this.couponStashStateList.add(newState);
-        this.commandTextHistory.add(command);
-        currStateIndex++;
-
         int stateSize = couponStashStateList.size();
         if (currStateIndex != stateSize - 1) {
 
             // Purging all coupon stash states and commandText histories after the currentStatePointer.
             for (int i = currStateIndex + 1; i < stateSize; i++) {
                 couponStashStateList.remove(couponStashStateList.size() - 1);
-                commandTextHistory.remove(couponStashStateList.size() - 1);
+                commandTextHistory.remove(commandTextHistory.size() - 1);
             }
         }
+
+        this.couponStashStateList.add(newState);
+        this.commandTextHistory.add(command);
+        currStateIndex++;
     }
 
     /**

--- a/src/main/resources/view/CommandCard.css
+++ b/src/main/resources/view/CommandCard.css
@@ -1,9 +1,10 @@
 * {
     -fx-text-fill: white;
+    -fx-font-size: 12.0;
 }
 
-#name {
+#name * {
     -fx-font-family: "Courier New";
     -fx-font-style: italic;
-    -fx-font-size: 26.0;
+    -fx-font-size: 26.0 !important;
 }

--- a/src/main/resources/view/CommandCard.fxml
+++ b/src/main/resources/view/CommandCard.fxml
@@ -6,7 +6,6 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 

--- a/src/test/java/csdev/couponstash/logic/commands/HelpCommandTest.java
+++ b/src/test/java/csdev/couponstash/logic/commands/HelpCommandTest.java
@@ -1,24 +1,21 @@
 package csdev.couponstash.logic.commands;
 
-import static csdev.couponstash.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static csdev.couponstash.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
+import static csdev.couponstash.logic.commands.HelpCommand.ERROR;
+import static csdev.couponstash.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
+import csdev.couponstash.logic.commands.exceptions.CommandException;
 
 import csdev.couponstash.model.Model;
 import csdev.couponstash.model.ModelManager;
 
 public class HelpCommandTest {
     private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
-    }
-
-    @Test
-    void execute() {
+    public void execute_error() {
+        HelpCommand helpCommand = new HelpCommand();
+        assertThrows(CommandException.class, ERROR, () -> helpCommand.execute(model));
     }
 }

--- a/src/test/java/csdev/couponstash/logic/commands/SortCommandTest.java
+++ b/src/test/java/csdev/couponstash/logic/commands/SortCommandTest.java
@@ -3,6 +3,7 @@ package csdev.couponstash.logic.commands;
 import static csdev.couponstash.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
 import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_NAME;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_REMIND;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -50,6 +51,23 @@ class SortCommandTest {
                 TypicalCoupons.BENSON,
                 TypicalCoupons.CARL,
                 TypicalCoupons.FIONA,
+                TypicalCoupons.GEORGE
+                ), model.getFilteredCouponList()
+        );
+    }
+
+    @Test
+    public void execute_sortByRemind() {
+        String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, PREFIX_REMIND);
+        SortCommand command = new SortCommand(PREFIX_REMIND);
+
+        expectedModel.sortCoupons(SortCommand.REMINDER_COMPARATOR);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(
+                TypicalCoupons.CARL,
+                TypicalCoupons.FIONA,
+                TypicalCoupons.BENSON,
+                TypicalCoupons.ALICE,
                 TypicalCoupons.GEORGE
                 ), model.getFilteredCouponList()
         );

--- a/src/test/java/csdev/couponstash/logic/parser/ShareCommandParserTest.java
+++ b/src/test/java/csdev/couponstash/logic/parser/ShareCommandParserTest.java
@@ -1,0 +1,28 @@
+package csdev.couponstash.logic.parser;
+
+import static csdev.couponstash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import org.junit.jupiter.api.Test;
+
+import csdev.couponstash.logic.commands.ShareCommand;
+
+import csdev.couponstash.testutil.TypicalIndexes;
+
+class ShareCommandParserTest {
+    private ShareCommandParser parser = new ShareCommandParser();
+
+    @Test
+    public void parse_validArgs() {
+        CommandParserTestUtil.assertParseSuccess(parser, "1",
+                new ShareCommand(TypicalIndexes.INDEX_FIRST_COUPON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        CommandParserTestUtil.assertParseFailure(
+                parser,
+                "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShareCommand.MESSAGE_USAGE)
+        );
+    }
+}

--- a/src/test/java/csdev/couponstash/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/csdev/couponstash/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,66 @@
+package csdev.couponstash.logic.parser;
+
+import static csdev.couponstash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_NAME;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_REMIND;
+import static csdev.couponstash.logic.parser.CliSyntax.PREFIX_TAG;
+
+import static csdev.couponstash.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static csdev.couponstash.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import csdev.couponstash.logic.commands.SortCommand;
+
+class SortCommandParserTest {
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    void parse_nameOnly_success() {
+        assertParseSuccess(
+                parser, " " + PREFIX_NAME.toString(),
+                new SortCommand(PREFIX_NAME)
+        );
+    }
+
+    @Test
+    void parse_remindOnly_success() {
+        assertParseSuccess(
+                parser, " " + PREFIX_REMIND.toString(),
+                new SortCommand(PREFIX_REMIND)
+        );
+    }
+
+    @Test
+    void parse_expiryDateOnly_success() {
+        assertParseSuccess(
+                parser, " " + PREFIX_EXPIRY_DATE.toString(),
+                new SortCommand(PREFIX_EXPIRY_DATE)
+        );
+    }
+
+    @Test
+    void parse_compulsoryFieldMissing_failure() {
+        assertParseFailure(
+                parser, " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)
+        );
+    }
+
+    @Test
+    void parse_multipleFields_failure() {
+        assertParseFailure(
+                parser, " " + PREFIX_NAME + " " + PREFIX_REMIND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)
+        );
+    }
+
+    @Test
+    void parse_invalidField_failure() {
+        assertParseFailure(
+                parser, " " + PREFIX_TAG,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE)
+        );
+    }
+}


### PR DESCRIPTION
Fixed undo redo bug. Fixes #266 

Help command now works offline. The command will extract a `help.html` file from the jar file if it is not present in current directory. Thus, this feature does not work when running from intellij, this only works when running from jar file. Fixes #258 

Sort command works with the `r/` prefix now.