### PR TITLE
Limit Saveables length

### DIFF
--- a/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
+++ b/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
@@ -297,7 +297,7 @@ public class ParserUtil {
      */
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
-        String trimmedTag = tag.trim();
+        String trimmedTag = checkStringLength(tag.trim(), Tag.STRING_LENGTH_LIMIT);
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
+++ b/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
@@ -37,6 +37,11 @@ import csdev.couponstash.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    // used to reject user input for text that is too long
+    // to be displayed properly by Coupon Stash
+    public static final String MESSAGE_STRING_TOO_LONG = "$1%s is too long! Length exceeds"
+            + " the limit of $2%d characters.";
+    public static final int SAVEABLES_STRING_LENGTH_LIMIT = 100;
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -328,5 +333,23 @@ public class ParserUtil {
         RemindDate remind = new RemindDate();
         remind.setRemindDate(LocalDate.parse(trimmedDate, DATE_FORMATTER));
         return remind;
+    }
+
+    /**
+     * Checks if a String exceeds a given limit on the
+     * number of characters, to avoid causing problems
+     * with the rendering of text on the UI.
+     *
+     * @param s The String to be checked.
+     * @param limit The int representing the character limit.
+     * @return Returns the original String s if it is
+     *         determined to fit within the limit.
+     * @throws ParseException If the String s exceeds the limit.
+     */
+    private static String checkStringLength(String s, int limit) throws ParseException {
+        if (s.length() > limit) {
+            throw new ParseException(String.format(ParserUtil.MESSAGE_STRING_TOO_LONG, s, limit));
+        }
+        return s;
     }
 }

--- a/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
+++ b/src/main/java/csdev/couponstash/logic/parser/ParserUtil.java
@@ -39,9 +39,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     // used to reject user input for text that is too long
     // to be displayed properly by Coupon Stash
-    public static final String MESSAGE_STRING_TOO_LONG = "$1%s is too long! Length exceeds"
-            + " the limit of $2%d characters.";
-    public static final int SAVEABLES_STRING_LENGTH_LIMIT = 100;
+    public static final String MESSAGE_STRING_TOO_LONG = "\"%1$s\" is too long! Length of"
+            + " %2$d exceeds the limit of %3$d characters.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -137,7 +136,7 @@ public class ParserUtil {
                     throw new ParseException(Savings.MULTIPLE_NUMBER_AMOUNTS);
                 }
             } else {
-                String trimmedSaveable = str.trim();
+                String trimmedSaveable = checkStringLength(str.trim(), Saveable.STRING_LENGTH_LIMIT);
                 // numbers might be a mistake by the user
                 if (trimmedSaveable.matches(".*\\d.*")) {
                     throw new ParseException(
@@ -347,8 +346,10 @@ public class ParserUtil {
      * @throws ParseException If the String s exceeds the limit.
      */
     private static String checkStringLength(String s, int limit) throws ParseException {
-        if (s.length() > limit) {
-            throw new ParseException(String.format(ParserUtil.MESSAGE_STRING_TOO_LONG, s, limit));
+        int currentLength = s.length();
+        if (currentLength > limit) {
+            throw new ParseException(String.format(
+                    ParserUtil.MESSAGE_STRING_TOO_LONG, s, currentLength, limit));
         }
         return s;
     }

--- a/src/main/java/csdev/couponstash/model/coupon/savings/Saveable.java
+++ b/src/main/java/csdev/couponstash/model/coupon/savings/Saveable.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 public class Saveable implements Comparable<Saveable> {
     public static final String MESSAGE_CONSTRAINTS = "Saveables should not be blank "
             + "or null, and must have a non-negative count field.";
+    // limit for the length of string possible
+    public static final int STRING_LENGTH_LIMIT = 20;
 
     private final String savedItem;
     private final int count;

--- a/src/main/java/csdev/couponstash/model/tag/Tag.java
+++ b/src/main/java/csdev/couponstash/model/tag/Tag.java
@@ -9,9 +9,10 @@ import static java.util.Objects.requireNonNull;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric, "
-            + "and at most 15 characters.";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,15}";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric.";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    // limit for the length of string possible
+    public static final int STRING_LENGTH_LIMIT = 15;
 
     public final String tagName;
 

--- a/src/main/java/csdev/couponstash/storage/JsonAdaptedSaveable.java
+++ b/src/main/java/csdev/couponstash/storage/JsonAdaptedSaveable.java
@@ -61,6 +61,6 @@ public class JsonAdaptedSaveable {
         if (!Saveable.isValidSaveableValue(this.saveableDesc, this.count)) {
             throw new IllegalValueException(Saveable.MESSAGE_CONSTRAINTS);
         }
-        return new Saveable(this.saveableDesc);
+        return new Saveable(this.saveableDesc, this.count);
     }
 }

--- a/src/main/resources/view/CouponCard.css
+++ b/src/main/resources/view/CouponCard.css
@@ -26,6 +26,7 @@
 #savings #saveables .sv-label {
     -fx-font-size: 14;
     -fx-label-padding: 0 3 0 3;
+    -fx-max-width: 100;
 }
 
 #couponName {

--- a/src/main/resources/view/SavingsBox.fxml
+++ b/src/main/resources/view/SavingsBox.fxml
@@ -9,5 +9,5 @@
       xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
    <Label fx:id="numericalAmount" alignment="CENTER" contentDisplay="CENTER"
           prefHeight="89.0" prefWidth="100.0" />
-   <FlowPane fx:id="saveables" prefHeight="29.0" prefWidth="100.0"/>
+   <FlowPane fx:id="saveables" prefHeight="29.0" prefWidth="100.0" minWidth="100.0" />
 </VBox>


### PR DESCRIPTION
New method in ParserUtil to check a String's length and throw an error message (fixes #270)

Also, fixes #228

Now, Saveables are limited to 20 characters. Example:
![image](https://user-images.githubusercontent.com/49450743/78550770-3d960e00-7837-11ea-9bb9-cc1e6a6b8e03.png)
![image](https://user-images.githubusercontent.com/49450743/78550774-3f5fd180-7837-11ea-9284-87f860e35e0c.png)

Edit: Savings Box is now forced to have a fixed width, so the above will no longer happen
![image](https://user-images.githubusercontent.com/49450743/78556894-67a0fd80-7842-11ea-90e6-c44a20d0cf4b.png)
