### PR TITLE
Add label for "Week of" to savings graph

### DIFF
--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -200,3 +200,10 @@
 #summary-tab #savings-chart #days-axis .axis-tick-mark {
   -fx-stroke-width: 0;
 }
+
+#summary-tab #savings-chart #days-axis .axis-label {
+  -fx-text-fill: white;
+  -fx-font-family: arial;
+  -fx-font-size: 11;
+  -fx-font-style: italic;
+}

--- a/src/main/resources/view/SummaryPane.fxml
+++ b/src/main/resources/view/SummaryPane.fxml
@@ -17,7 +17,7 @@
     <HBox alignment="CENTER" prefHeight="338.0" prefWidth="643.0">
       <BarChart id="savings-chart" fx:id="savingsChart" prefHeight="338.0" prefWidth="321.0" style="-fx-padding: 10.0;">
         <xAxis>
-          <CategoryAxis id="days-axis" fx:id="daysAxis" />
+          <CategoryAxis id="days-axis" fx:id="daysAxis" label="(Week of)" />
         </xAxis>
         <yAxis>
           <NumberAxis id="savings-axis" fx:id="savingsAxis" />


### PR DESCRIPTION
Fixed #260 by making it more obvious that the graph is by week, not day

Preview:
![image](https://user-images.githubusercontent.com/49450743/78558028-7be5fa00-7844-11ea-8438-1638f03afe5d.png)

